### PR TITLE
delete main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
`main.rs` is unnecessary since this crate is a library. In the future, you can use `cargo init --lib` or `cargo new my_crate --lib` in order to start with the template for a library instead of the template for an executable.