### PR TITLE
change visibility of modules rw, mutex, sync

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
-mod rw;
-mod mutex;
-mod sync;
+pub mod rw;
+pub mod mutex;
+pub mod sync;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,2 +1,2 @@
-mod rw;
-mod mutex;
+pub mod rw;
+pub mod mutex;


### PR DESCRIPTION
Modules need to be public for the users of your crate to be able to access them and their contents. Alternatively, you can keep the modules private, and re-export their contents, like this:
```rs
mod private_module {
    pub struct SomeType {
        ...
    }
}

pub use private_module::SomeType;
```
If you do this, assuming that the above code snippet is in `lib.rs`, then users would refer to the type as `libname::SomeType` rather than `libname::private_module::SomeType`.